### PR TITLE
DC Life app_id를 사용해 작동하도록 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/geeksbaek/goinside?status.svg)](https://godoc.org/github.com/geeksbaek/goinside)
 
 이 라이브러리는 디시인사이드 비공식 API 입니다.
-API에 대한 설명은 [godoc](https://godoc.org/github.com/geeksbaek/goinside)에서 보실 수 있습니다. 
-
-## Notice
-
-이 라이브러리는 현재 디시인사이드 API에 대응되지 않습니다. 다시 말해 동작하지 않습니다.
-
-또한, 개발자 본인이 [아키에이지](http://archeage.nexon.com/) 하느라 바쁜 관계로 관리를 잠정 중단합니다.
+API에 대한 설명은 [godoc](https://godoc.org/github.com/geeksbaek/goinside)에서 보실 수 있습니다.
 
 ## Install
 ```

--- a/gallog/gallog.go
+++ b/gallog/gallog.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/PuerkitoBio/goquery"
-	".."
+	"github.com/geeksbaek/goinside"
 )
 
 const (

--- a/gallog/gallog.go
+++ b/gallog/gallog.go
@@ -12,10 +12,11 @@ import (
 	"sync"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/geeksbaek/goinside"
+	".."
 )
 
 const (
+	loginChkQuery = `input[name="url"] + input`
 	articlesQuery = `td[valign='top'] td[colspan='2'] table tr:not(:first-child)`
 	articleQuery  = `img`
 	commentsQuery = `td[colspan='2'][align='center'] td[colspan='2'] table tr:not(:first-child)`
@@ -45,13 +46,24 @@ type Session struct {
 
 // Login 함수는 해당 ID와 PASSWORD로 로그인한 뒤 해당 세션을 반환합니다.
 func Login(id, pw string) (s *Session, err error) {
-	form := makeForm(map[string]string{
+	loginPageResp := do("GET", desktopLoginPageURL, nil, nil, desktopRequestHeader)
+	doc, err := goquery.NewDocumentFromResponse(loginPageResp)
+
+	chk := doc.Find(loginChkQuery)
+	chkName, _ := chk.Attr("name")
+	chkValue, _ := chk.Attr("value")
+
+	f := map[string]string{
 		"s_url":    "http://www.dcinside.com/",
-		"ssl":      "Y",
+		"ssl_chk":  "on",
 		"user_id":  id,
 		"password": pw,
-	})
+	}
+	f[chkName] = chkValue
+
+	form := makeForm(f)
 	resp := do("POST", desktopLoginURL, nil, form, desktopRequestHeader)
+
 	ms, err := goinside.Login(id, pw)
 	if err != nil {
 		return

--- a/gallog/request.go
+++ b/gallog/request.go
@@ -9,6 +9,7 @@ import (
 
 // web urls
 const (
+	desktopLoginPageURL = "https://dcid.dcinside.com/join/login.php?s_url=http%3A%2F%2Fwww.dcinside.com" // s_url 없으면 에러남
 	desktopLoginURL     = "https://dcid.dcinside.com/join/member_check.php"
 	desktopLogoutURL    = "https://dcid.dcinside.com/join/logout.php"
 	deleteArticleLogURL = "http://gallog.dcinside.com/inc/_deleteArticle.php"

--- a/request.go
+++ b/request.go
@@ -53,7 +53,7 @@ func (api dcinsideAPI) get(m map[string]string) (*http.Response, error) {
 }
 
 // AppID 는 디시인사이드 API 요청에 필요한 Key 값입니다.
-const AppID = "V1hhdDJrV2NmczBQYWcrUk1FOEJ3NTNjaUhscllLVVFadHNXemZCMmlHRT0%3D"
+const AppID = "SEMwMFcxYUpsU0Z1cUVidDQvbXV5QT09"
 
 // apis
 const (
@@ -83,8 +83,7 @@ const (
 
 var (
 	apiRequestHeader = map[string]string{
-		"User-Agent": "dcinside.app",
-		"Referer":    "http://www.dcinside.com",
+		"User-Agent": "dclife",
 		"Host":       "m.dcinside.com",
 	}
 	mobileRequestHeader = map[string]string{


### PR DESCRIPTION
아직 디랖의 app_id는 변경되지 않는 값으로 남아있으므로, 해당 값으로 app_id를 변경해 다시 사용 가능한 상태로 만듬
그 외에 PC 버전 로그인이 되지 않는 문제도 수정

포함된 test 및 goinside-gallog-cleaner로 작동되는 것 확인
